### PR TITLE
Adds Java CI workflow status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Huddle
+
+[![](https://github.com/ybhatnagar/huddle/workflows/Java%20CI/badge.svg)](https://github.com/ybhatnagar/huddle/actions)
+
 Huddle generates smart and feasible recommendations for migration plans to reduce overall latency in distributed containerized applications. More details can be found over in the wiki.
 
 ## Overview:


### PR DESCRIPTION
Status badges show whether a workflow is currently failing or passing. By default, badges display the status of your default branch (usually master).